### PR TITLE
Update gnucli in meson build file with '--logfile' option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,6 +61,10 @@ ncat = find_program('ncat', required: false)
 cat = find_program('cat').path()
 
 psk = '7df28f5439b5a051cc138b6e12128264'
+
+logfile = run_command(gnuclt, '--logfile', '/dev/null')
+option_exist = not (logfile.stderr().contains('illegal option'))
+
 foreach n: ['4', '6']
   h = 'localhost' + n
 
@@ -93,9 +97,9 @@ foreach n: ['4', '6']
     ]]]
   endif
 
-  if gnuclt.found() and false
+  if gnuclt.found() and option_exist
     tests += [[n, 'PSK', 'clt', 'gnutls-cli', false, [
-      gnuclt.path(), '-p', '%PORT%', '--pskusername=foo', '--pskkey=' + psk,
+      gnuclt.path(), '-p', '%PORT%', '--logfile', '/dev/null', '--pskusername=foo', '--pskkey=' + psk,
                      '--priority', 'NORMAL:+ECDHE-PSK:+DHE-PSK:+PSK', h
     ]]]
   endif


### PR DESCRIPTION
We should make sure '--logfile' option is enabled in its new version.
If '--logfile' is not an illegal option, then we could enable the
tests of gnutls-cli.

Signed-off-by: Ke Zhao <kzhao@redhat.com>